### PR TITLE
SAN-3886 remove install referrer dependency

### DIFF
--- a/src/scripts/android/updateAndroidManifest.js
+++ b/src/scripts/android/updateAndroidManifest.js
@@ -125,25 +125,25 @@
     receivers = removeBasedOnAndroidName(receivers, androidName);
 
     // add new
-    manifest.manifest.application[0].receiver = receivers.concat([
-      {
-        $: {
-          "android:name": androidName,
-          "android:exported": true
-        },
-        "intent-filter": [
-          {
-            action: [
-              {
-                $: {
-                  "android:name": "com.android.vending.INSTALL_REFERRER"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ]);
+    // manifest.manifest.application[0].receiver = receivers.concat([
+    //   {
+    //     $: {
+    //       "android:name": androidName,
+    //       "android:exported": true
+    //     },
+    //     "intent-filter": [
+    //       {
+    //         action: [
+    //           {
+    //             $: {
+    //               "android:name": "com.android.vending.INSTALL_REFERRER"
+    //             }
+    //           }
+    //         ]
+    //       }
+    //     ]
+    //   }
+    // ]);
 
     return manifest;
   }


### PR DESCRIPTION
This is causing crashing upon the first install of the application. It appears to have been optional initially, but now I believe it is deprecated, so we don't want to include it.