### PR TITLE
Fix build issue

### DIFF
--- a/src/ios/AppDelegate+BranchSdk.m
+++ b/src/ios/AppDelegate+BranchSdk.m
@@ -2,11 +2,8 @@
 
 #import "BranchNPM.h"
 
-#ifdef BRANCH_NPM
-#import "Branch.h"
-#else
 #import <Branch/Branch.h>
-#endif
+
 
 // Provides Ionic Capacitor compatibility
 #import <Cordova/CDVPlugin.h>

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -1,14 +1,8 @@
 #import "BranchNPM.h"
 
-#ifdef BRANCH_NPM
-#import "Branch.h"
-#import "BranchLinkProperties.h"
-#import "BranchUniversalObject.h"
-#else
 #import <Branch/Branch.h>
 #import <Branch/BranchLinkProperties.h>
 #import <Branch/BranchUniversalObject.h>
-#endif
 
 #import <Cordova/CDV.h>
 


### PR DESCRIPTION
This newer style of imports seems to cause issues when building via cli. Xcode corrects them while compiling, but
for some reason it doesn't happen when built via cli.